### PR TITLE
Bugfix/fix single quotes

### DIFF
--- a/fophidian.ts
+++ b/fophidian.ts
@@ -276,6 +276,7 @@ export function createPipeKit() {
 
   /**
    * Provides quick way to frontload pipe tasks.
+   * There is an assumption here that the manifest json wont be hotswapped.
    */
   function getPrimingPipers(): Easydo[] {
     const doCopyManifestToSlab = () =>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "^3.3.0",
 		"copy-newer": "^2.1.2",
+		"dedent": "^1.5.1",
 		"dotenv": "^16.3.1",
 		"esbuild": "^0.19.5",
 		"esbuild-plugin-copy": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   '@typescript-eslint/parser': 5.29.0
   builtin-modules: ^3.3.0
   copy-newer: ^2.1.2
+  dedent: ^1.5.1
   dotenv: ^16.3.1
   esbuild: ^0.19.5
   esbuild-plugin-copy: ^2.1.1
@@ -44,6 +45,7 @@ devDependencies:
   '@typescript-eslint/parser': 5.29.0_fnh4vuzk5u3zhnhoyyeyy42m64
   builtin-modules: 3.3.0
   copy-newer: 2.1.2
+  dedent: 1.5.1
   dotenv: 16.3.1
   esbuild: 0.19.5
   esbuild-plugin-copy: 2.1.1_esbuild@0.19.5

--- a/src/parser/MarkdownParser.test.ts
+++ b/src/parser/MarkdownParser.test.ts
@@ -2,107 +2,136 @@ import { splitIntoFrontMatterAndContents } from "./MarkdownParser";
 import * as MarkdownParser from "./MarkdownParser";
 import * as utils from "../utils/index";
 import * as yaml from "yaml";
-
+import dedent from "dedent";
 jest.mock(
-	"obsidian",
-	() => {
-		return {
-			parseYaml: (yaml_content: string) => {
-				return yaml.parse(yaml_content);
-			},
-		};
-	},
-	{ virtual: true }
+  "obsidian",
+  () => {
+    return {
+      parseYaml: (yaml_content: string) => {
+        return yaml.parse(yaml_content);
+      },
+    };
+  },
+  { virtual: true }
 );
 
-const markdown = `---
-list: me
-bird: two
----
-poo
-`;
+const SIMPLE_MARKDOWN_FRONTMATTER = processDedent(`
+	---
+	list: me
+	bird: two
+	---
+	poo
+	`);
 
-const markdownWithArrays = `---
-tabs:
-  - 5
-  - batman
-cabs:
-  - fiver
-  - ten
----
-content
-`;
+const MARKDOWN_ARRAYS = processDedent(`
+  ---
+  tabs:
+    - 5
+    - batman
+  cabs:
+    - fiver
+    - ten
+  ---
+  content
+  `);
 
 describe("MarkdownParser::splitIntoFrontMatterAndContents", () => {
-	it("should split the frontmatter and content cleanly", () => {
-		const frontmatter = `
-list: me
-bird: two
-`;
-		const content = `poo`;
+  const frontmatter = processDedent(`
+    list: me
+    bird: two
+  `);
+  it("should split the frontmatter and content cleanly", () => {
+    const content = `poo\n`;
 
-		const actual = splitIntoFrontMatterAndContents(markdown);
-		expect("\n" + actual.processedFrontMatter.frontMatter).toEqual(
-			frontmatter
-		);
-		expect(actual.processedNonFrontMatter.content).toEqual(content);
-	});
+    const actual = splitIntoFrontMatterAndContents(SIMPLE_MARKDOWN_FRONTMATTER);
 
-	it("should split up frontmatter and nonfm even with arrays", () => {
-		const frontmatter = `
-tabs:
-  - 5
-  - batman
-cabs:
-  - fiver
-  - ten
-`;
-		const actual = splitIntoFrontMatterAndContents(markdownWithArrays);
-		expect("\n" + actual.processedFrontMatter.frontMatter).toEqual(
-			frontmatter
-		);
-		expect(actual.processedNonFrontMatter.content).toEqual("content");
-	});
+    expect(actual.processedFrontMatter.frontMatter).toEqual(frontmatter);
+    expect(actual.processedNonFrontMatter.content).toEqual(content);
+  });
+
+  const shouldSplitUpEvenWithArraysSample = `
+  tabs:
+    - 5
+    - batman
+  cabs:
+    - fiver
+    - ten
+  `;
+  it("should split up frontmatter and nonfm even with arrays", () => {
+    const expected_frontmatter = processDedent(
+      shouldSplitUpEvenWithArraysSample
+    );
+    const actual = splitIntoFrontMatterAndContents(MARKDOWN_ARRAYS);
+    expect(actual.processedFrontMatter.frontMatter).toEqual(
+      expected_frontmatter
+    );
+    expect(actual.processedNonFrontMatter.content).toEqual("content\n");
+  });
+
+  const improperContentSample = `
+  ---
+  hi: dkfjdkfjdf
+  ---BUG BUG
+  `;
+  it("should return null when formatted improperly", () => {
+    // const expected_frontmatter = processDedent(improperContentSample);
+    const actual = splitIntoFrontMatterAndContents(
+      processDedent(improperContentSample)
+    );
+    expect(actual).toBe(null);
+  });
 });
 
 describe("MarkdownParser::replaceFileContentsWithSortedFrontMatter", () => {
-	it("should sort simple literals", () => {
-		const expected_markdown = `---
-bird: two
-list: me
----
-poo`;
-		const actual = splitIntoFrontMatterAndContents(markdown);
+  const simpleLiteralSample = `---
+  bird: two
+  list: me
+  ---
+  poo
+  `;
 
-		const actual_markdown =
-			MarkdownParser.replaceFileContentsWithSortedFrontMatter(
-				actual.processedFrontMatter.frontMatter,
-				actual.processedNonFrontMatter.content,
-				utils.sortBy
-			);
+  it("should sort simple literals", () => {
+    const expected_markdown = processDedent(simpleLiteralSample);
 
-		//
-		expect(expected_markdown).toEqual(actual_markdown);
-	});
-	it("should sort arrays", () => {
-		const expected_markdown = `---
-cabs:
-  - fiver
-  - ten
-tabs:
-  - batman
-  - 5
----
-content`;
-		const actual = splitIntoFrontMatterAndContents(markdownWithArrays);
+    const actual = splitIntoFrontMatterAndContents(SIMPLE_MARKDOWN_FRONTMATTER);
+    const actual_markdown =
+      MarkdownParser.replaceFileContentsWithSortedFrontMatter(
+        actual.processedFrontMatter.frontMatter,
+        actual.processedNonFrontMatter.content,
+        utils.sortBy
+      );
 
-		const actual_markdown =
-			MarkdownParser.replaceFileContentsWithSortedFrontMatter(
-				actual.processedFrontMatter.frontMatter,
-				actual.processedNonFrontMatter.content,
-				utils.sortBy
-			);
+    //
+    // console.log({ expected_markdown, actual, actual_markdown });
+    expect(expected_markdown).toEqual(actual_markdown);
+  });
 
-		expect(expected_markdown).toEqual(actual_markdown);
-	});
+  const shouldSortArraysSample = `---
+    cabs:
+      - fiver
+      - ten
+    tabs:
+      - batman
+      - 5
+    ---
+    content
+    `;
+  it("should sort arrays", () => {
+    const expected_markdown = processDedent(shouldSortArraysSample);
+
+    const actual = splitIntoFrontMatterAndContents(MARKDOWN_ARRAYS);
+
+    const actual_markdown =
+      MarkdownParser.replaceFileContentsWithSortedFrontMatter(
+        actual.processedFrontMatter.frontMatter,
+        actual.processedNonFrontMatter.content,
+        utils.sortBy
+      );
+
+    expect(expected_markdown).toEqual(actual_markdown);
+  });
 });
+
+function processDedent(markdown: string) {
+  return dedent(markdown) + "\n";
+}

--- a/src/parser/MarkdownParser.ts
+++ b/src/parser/MarkdownParser.ts
@@ -27,7 +27,7 @@ interface MarkdownParserImpl {
 export class MarkdownParser implements MarkdownParserImpl {
   public convertObjToYaml(
     obj: Record<string, unknown>,
-    yamlConfig?: { flowLevel: number; styles: { "!!null": string } }
+    yamlConfig?: jsyaml.YamlConfig
   ): ReturnType<typeof replaceFileContentsWithSortedFrontMatter> {
     throw new Error("Method not implemented.");
   }
@@ -64,14 +64,15 @@ MarkdownParser.prototype.replaceFileContentsWithSortedFrontMatter =
   replaceFileContentsWithSortedFrontMatter;
 MarkdownParser.prototype.convertObjToYaml = convertObjToYaml;
 
-export const manuYamlConfig = () => {
+export const manuYamlConfig = (): jsyaml.YamlConfig => {
   const yamlConfig = {
     flowLevel: 3,
     styles: {
-      "!!null": "camelcase",
+      "!!null": "empty",
     },
+    quotingType: '"',
   };
-  return yamlConfig;
+  return yamlConfig as jsyaml.YamlConfig;
 };
 
 export function convertObjToYaml(

--- a/src/parser/MarkdownParser.ts
+++ b/src/parser/MarkdownParser.ts
@@ -145,8 +145,9 @@ export function splitIntoFrontMatterAndContents(
     blockFrom: startingStartIndex,
     blockTo: endingEndMatchIdx,
   };
+
   const processedNonFrontMatter = {
-    content: file_contents.slice(endingEndMatchIdx, fileEndIdx),
+    content: file_contents.slice(endingEndMatchIdx, fileEndIdx + 1),
     from: endingEndMatchIdx,
     to: fileEndIdx,
   };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,19 +1,20 @@
 declare module "copy-newer" {
-	function copyNewer(
-		braced_target_files: string,
-		dir: string,
-		options: unknown
-	): Promise<void>;
-	export = copyNewer;
+  function copyNewer(
+    braced_target_files: string,
+    dir: string,
+    options: unknown
+  ): Promise<void>;
+  export = copyNewer;
 }
 
 declare module "js-yaml" {
-	export interface YamlConfig {
-		[key: string]: unknown;
-	}
+  export interface YamlConfig {
+    [key: string]: unknown;
+    quotingType?: '"' | "'";
+  }
 
-	export function dump(
-		obj: Record<string, unknown>,
-		options?: YamlConfig
-	): string;
+  export function dump(
+    obj: Record<string, unknown>,
+    options?: YamlConfig
+  ): string;
 }


### PR DESCRIPTION
Update tests to use dedent to make it easier to read the sample markdown.
Uncovered a non critical out of bounds error in parser in the process of fixing double quotes.
Wrap quotes in double to fix bug where single quotes interefere ''' <--bad. "'" <---good.

Also leave empty markdown property as "" rather than Null which is converted to a string and not really null. The other specific would be the canonical placeholder ~. empty string is better, visually.